### PR TITLE
Include null depts in result

### DIFF
--- a/levergreen_dbt/models/intermediate/int_greenhouse_departments_expanded_with_outline.sql
+++ b/levergreen_dbt/models/intermediate/int_greenhouse_departments_expanded_with_outline.sql
@@ -21,6 +21,7 @@ jobs_outline_unnested as (
         greenhouse_jobs_outline.full_opening_link, 
         greenhouse_jobs_outline.opening_title,
         greenhouse_jobs_outline.job_board,
+        greenhouse_jobs_outline.company_name,
         lower(greenhouse_jobs_outline.location) like '%remote%' as is_remote,
         department_ids_unnested.department_id
     from greenhouse_jobs_outline, unnest(string_to_array(department_ids, ',')) as department_ids_unnested(department_id)
@@ -29,8 +30,9 @@ jobs_outline_unnested as (
 outline_joined_to_depts as (
     select 
         jobs_outline_unnested.*,
-        greenhouse_job_departments.company_name,
-        case when greenhouse_job_departments.department_category = 'level-0' then greenhouse_job_departments.department_name end as primary_department,
+        case 
+            when greenhouse_job_departments.department_category = 'level-0' then greenhouse_job_departments.department_name 
+            when jobs_outline_unnested.department_id = 'No Dept' then 'No Department' end as primary_department,
         case when greenhouse_job_departments.department_category = 'level-1' then greenhouse_job_departments.department_name end as secondary_department,
         case when greenhouse_job_departments.department_category = 'level-2' then greenhouse_job_departments.department_name end as tertiary_department,
         case when greenhouse_job_departments.department_category = 'level-3' then greenhouse_job_departments.department_name end as quaternary_department

--- a/levergreen_dbt/models/staging/greenhouse/_greenhouse__models.yml
+++ b/levergreen_dbt/models/staging/greenhouse/_greenhouse__models.yml
@@ -57,7 +57,7 @@ models:
            "created_date_utc", "updated_date_utc",
             "source", "department_ids", "location", "office_ids",
             "full_opening_link", "opening_title", "uses_existing",
-            "raw_html_file_location", "run_hash", "job_board"]
+            "raw_html_file_location", "run_hash", "job_board", 'company_name']
     columns:
       - name: id
         description: serial id created by postgres upon insertion
@@ -81,6 +81,8 @@ models:
         description: Comma separated list of locations
       - name: full_opening_link
         description: Source of the actual job posting. Scraped value is only the suffix of the link, here we clean to have the full link.
+      - name: company_name
+        description: Company name from Greenhouse. Taken by grabbing the end of the source.
       - name: opening_title
         description: Name of the role
       - name: raw_html_file_location

--- a/levergreen_dbt/models/staging/greenhouse/_greenhouse__sources.yml
+++ b/levergreen_dbt/models/staging/greenhouse/_greenhouse__sources.yml
@@ -91,11 +91,6 @@ sources:
             - not_null
         - name: department_ids
           description: Comma separated list of Greenhouse department_ids. Will use this to join to greenhouse_job_deparments further on in data models
-          tests:
-            - not_null:
-                config:  
-                  severity: error
-                  where: "opening_title != 'Don''t see the right opportunity? Apply here!' and opening_title != 'General Application' and opening_link != '/atbayjobs/jobs/5792164003' and opening_link != '/atbayjobs/jobs/5808689003'" #Exclude generic applications
         - name: office_ids
           description: Comma separated list of of office_ids. Sometimes null in the source data, not sure why
         - name: location

--- a/levergreen_dbt/models/staging/greenhouse/stg_greenhouse__jobs_outline.sql
+++ b/levergreen_dbt/models/staging/greenhouse/stg_greenhouse__jobs_outline.sql
@@ -32,6 +32,10 @@ greenhouse_outlines_by_levergreen_id as (
             when is_embedded then opening_link
             else concat(source,'/',split_part(opening_link,'/',3),'/',split_part(opening_link,'/',4)) 
         end as full_opening_link,
+        case
+            when is_embedded then split_part(source,'=',-1)
+            else split_part(source,'/',-1)
+        end as company_name,
         cast(existing_html_used as boolean) as uses_existing,
         row_number() over(
             partition by opening_link, updated_date_utc
@@ -53,7 +57,8 @@ select
     uses_existing,
     raw_html_file_location,
     run_hash,
-    department_ids,
+    company_name,
+    coalesce(department_ids, 'No Dept') as department_ids,
     location,
     office_ids,
     full_opening_link,

--- a/levergreen_dbt/tests/confirm_active_jobs_per_company_scraped.sql
+++ b/levergreen_dbt/tests/confirm_active_jobs_per_company_scraped.sql
@@ -13,7 +13,6 @@ with unique_active_jobs_per_company as (
 sources as (
     select run_hash, source, 'greenhouse' as job_board, count(*) as num_source_openings 
     from {{ source('greenhouse', 'greenhouse_jobs_outline') }}
-    where department_ids is not null --excludes a couple broken links from source (General Applications)
     group by 1,2,3
     union all
     select run_hash, source, 'lever' as job_board, count(*) as num_source_openings 


### PR DESCRIPTION
Seeing multiple greenhouse pages include roles which do not have departments. While this is an error at the source, it appears since this has happened multiple times that we should account for this and allow greenhouse companies to have no departments.

From this, we also needed to refactor the code the grab the company name from the jobs outline rather than the job department, since not all companies have a job department. Since this is easily derived, it may be worth removing the company name export in the scrapy spider.

We also need to coalesce a department into our staging model or the unnesting doesn't work